### PR TITLE
Fix LLaMA 2 prompt format.

### DIFF
--- a/easyllm/prompt_utils/llama2.py
+++ b/easyllm/prompt_utils/llama2.py
@@ -23,7 +23,7 @@ def build_llama2_prompt(messages: Union[List[ChatMessage], str]) -> str:
         if message.role == "user":
             conversation.append(message.content.strip())
         elif message.role == "assistant":
-            conversation.append(f" [/INST] {message.content}</s><s>[INST] ")
+            conversation.append(f" [/INST] {message.content} </s><s>[INST] ")
         elif message.role == "function":
             raise ValueError("Llama 2 does not support function calls.")
         elif message.role == "system" and index == 0:


### PR DESCRIPTION
I added these lines to [generation.py](https://github.com/facebookresearch/llama/blob/main/llama/generation.py) to see the exact tokens being input into LLaMA:

```py
             prompt_tokens.append(dialog_tokens)

+        for pt in prompt_tokens:
+            print("Prompt tokens:")
+            print(pt)
+            print("Decoded:")
+            print(self.tokenizer.decode(pt))
         generation_tokens, generation_logprobs = self.generate(
```

And for this message series:
```py
messages = [
    {"role": "user", "content": "I am going to Paris, what should I see?"},
    {
        "role": "assistant",
        "content": """\
Paris, the capital of France, is known for its stunning architecture, art museums, historical landmarks, and romantic atmosphere. Here are some of the top attractions to see in Paris:

1. The Eiffel Tower: The iconic Eiffel Tower is one of the most recognizable landmarks in the world and offers breathtaking views of the city.
2. The Louvre Museum: The Louvre is one of the world's largest and most famous museums, housing an impressive collection of art and artifacts, including the Mona Lisa.
3. Notre-Dame Cathedral: This beautiful cathedral is one of the most famous landmarks in Paris and is known for its Gothic architecture and stunning stained glass windows.

These are just a few of the many attractions that Paris has to offer. With so much to see and do, it's no wonder that Paris is one of the most popular tourist destinations in the world.""",
    },
    {"role": "user", "content": "What is so great about #1?"},
]
```

Meta's code gives these tokens:
```
[1, 518, 25580, 29962, 306, 626, 2675, 304, 3681, 29892, 825, 881, 306, 1074, 29973, 518, 29914, 25580, 29962, 3681, 29892, 278, 7483, 310, 3444, 29892, 338, 2998, 363, 967, 380, 27389, 11258, 29892, 1616, 19133, 29879, 29892, 15839, 2982, 22848, 29892, 322, 6017, 7716, 25005, 29889, 2266, 526, 777, 310, 278, 2246, 19650, 1953, 304, 1074, 297, 3681, 29901, 13, 13, 29896, 29889, 450, 382, 2593, 295, 23615, 29901, 450, 9849, 293, 382, 2593, 295, 23615, 338, 697, 310, 278, 1556, 5936, 13902, 2982, 22848, 297, 278, 3186, 322, 16688, 2078, 271, 400, 5086, 8386, 310, 278, 4272, 29889, 13, 29906, 29889, 450, 4562, 12675, 6838, 29901, 450, 4562, 12675, 338, 697, 310, 278, 3186, 29915, 29879, 10150, 322, 1556, 13834, 19133, 29879, 29892, 27261, 385, 21210, 573, 4333, 310, 1616, 322, 24238, 29879, 29892, 3704, 278, 2598, 29874, 29420, 29889, 13, 29941, 29889, 24337, 29899, 29928, 420, 315, 21471, 29901, 910, 9560, 274, 21471, 338, 697, 310, 278, 1556, 13834, 2982, 22848, 297, 3681, 322, 338, 2998, 363, 967, 22883, 293, 11258, 322, 380, 27389, 380, 7114, 12917, 5417, 29889, 13, 13, 1349, 968, 526, 925, 263, 2846, 310, 278, 1784, 19650, 1953, 393, 3681, 756, 304, 5957, 29889, 2973, 577, 1568, 304, 1074, 322, 437, 29892, 372, 29915, 29879, 694, 4997, 393, 3681, 338, 697, 310, 278, 1556, 5972, 6282, 391, 15422, 800, 297, 278, 3186, 29889, 29871, 2, 1, 518, 25580, 29962, 1724, 338, 577, 2107, 1048, 396, 29896, 29973, 518, 29914, 25580, 29962]
```

Using this repository, I get a slightly different result:
```py
chat_messages = [ChatMessage(content=m["content"], role=m["role"]) for m in messages]
prompt = build_llama2_prompt(chat_messages)
print(tokenizer.encode(prompt, add_special_tokens=False))
```

<img width="994" alt="image" src="https://github.com/float-trip/easyllm/assets/102226344/45a35b0f-0b8a-428b-8e43-7b5405aebb1c">

There's one missing token for `29871`/`▁`. Adding a space before `</s>` fixes this.